### PR TITLE
Handles scrollbar removal without changing document width

### DIFF
--- a/public/js/modules/nav-mobile.js
+++ b/public/js/modules/nav-mobile.js
@@ -5,6 +5,7 @@
  * Edits will be overwritten if you change the file locally
  */
 import { qs, qsa } from './query.js';
+import { removeScroll, resetScroll } from './scrollbar.js';
 import { getFocusableElement, trapFocusForward, trapReverseFocus } from './focus.js';
 
 /**
@@ -80,11 +81,7 @@ function addMobileNav(resizedEventName) {
     }
 
     function openMobileMenu(){
-        const w1 = document.body.getBoundingClientRect().width;
-        document.body.style.overflow = 'hidden';
-        const w2 = document.body.getBoundingClientRect().width;
-        document.documentElement.style.color = 'red';
-        document.documentElement.style.paddingInlineEnd = (w2 - w1) + 'px';
+        removeScroll();
         
         const menuElement = qs('#' + navigationSelector);
         
@@ -132,8 +129,7 @@ function addMobileNav(resizedEventName) {
     function closeMobileMenu() {
         const menuElement = qs('#' + navigationSelector);
         menuElement.style.display = '';
-        document.body.style.overflow = 'auto';
-        document.documentElement.style.paddingInlineEnd = '0';
+        resetScroll();
 
         if (icon.getAttribute(dataOpen) === dataOpen) {
             overlay.innerHTML = '';

--- a/public/js/modules/scrollbar.js
+++ b/public/js/modules/scrollbar.js
@@ -1,0 +1,13 @@
+function removeScroll() {
+    const w1 = document.body.getBoundingClientRect().width;
+    document.body.style.overflow = 'hidden';
+    const w2 = document.body.getBoundingClientRect().width;
+    document.documentElement.style.paddingInlineEnd = (w2 - w1) + 'px';
+}
+
+function resetScroll() {
+    document.body.style.overflow = 'auto';
+    document.documentElement.style.paddingInlineEnd = '0';
+}
+
+export { removeScroll, resetScroll }

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -2,6 +2,7 @@
 
 import { qs } from "./modules/query.js";
 import { raiseEvent } from "./modules/events.js";
+import { removeScroll, resetScroll } from './modules/scrollbar.js';
 import { contains, sanitise, explode, highlight } from "./modules/string.js";
 import { stemmer } from "./modules/stemmer.js";
 
@@ -120,14 +121,14 @@ function initializeSearch() {
   function activateInput() {
     if (siteSearchWrapper.classList.contains("is-active")) return;
     siteSearchWrapper.classList.add("is-active");
-    document.body.style.overflow = "hidden";
+    removeScroll();
   }
 
   function deactivateInput() {
     if (!siteSearchWrapper.classList.contains("is-active")) return;
     siteSearchWrapper.classList.remove("is-active");
     siteSearchInput.blur();
-    document.body.style.overflow = "";
+    resetScroll();
   }
 
   function openDropdown() {


### PR DESCRIPTION
When removing the scrollbar, this utility makes sure the document doesn't change width - as that causes a visible layout shift.

Extracted into a module so the navigation and search can re-use it.